### PR TITLE
fix flow crash

### DIFF
--- a/app/src/main/java/com/rayman/jsonpad/ui/navigation/Navgraph.kt
+++ b/app/src/main/java/com/rayman/jsonpad/ui/navigation/Navgraph.kt
@@ -38,22 +38,24 @@ fun NoteNavGraph(navController: NavHostController, viewModel: NoteViewModel = hi
 
             val noteId = backStackEntry.arguments?.getString("noteId")
             // completed Toast.makeText(context, "Error: Note ID is missing!$noteId" , Toast.LENGTH_SHORT).show()
-            val noteState = viewModel.getNoteById(noteId ?: "")
-            val note by  noteState.collectAsState(initial = null)
+            val note by  viewModel.getNoteById(noteId ?: "").collectAsState(initial = null)
             var newNote by rememberSaveable { mutableStateOf<Note?>(null) }
 
 
-            if (note == null) {
-                LaunchedEffect(noteId) {
-                newNote = viewModel.addNote("", "", "") // Create a new empty note
+            LaunchedEffect(noteId, note) {
+                if (note == null) {
+                    newNote = viewModel.addNote("", "", "") // Create a new empty note
                     Toast.makeText(context, "Error: Note ID is missing!${newNote!!.title}" , Toast.LENGTH_SHORT).show()
                 }
             }
-            EditNoteScreen(
-                note = note ?: newNote, onNoteUpdated = { navController.popBackStack() },
-                viewModel = hiltViewModel(),
-                onBack = {navController.popBackStack()}
-            )
+
+            (note ?: newNote)?.let {
+                EditNoteScreen(
+                    note = it, onNoteUpdated = { navController.popBackStack() },
+                    viewModel = hiltViewModel(),
+                    onBack = {navController.popBackStack()}
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/rayman/jsonpad/ui/viewmodel/NoteViewModel.kt
+++ b/app/src/main/java/com/rayman/jsonpad/ui/viewmodel/NoteViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.rayman.jsonpad.data.local.Note
 import com.rayman.jsonpad.data.repository.NoteRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -26,9 +27,9 @@ class NoteViewModel @Inject constructor(private val repository: NoteRepository) 
         initialValue = emptyList()
     )
 
-    fun getNoteById(id: String): StateFlow<Note?> {
+    fun getNoteById(id: String): Flow<Note?> {
         return repository.allNotes
-            .map { notes -> notes.find { it.id.toString() == id } } as StateFlow<Note?>
+            .map { notes -> notes.find { it.id.toString() == id } }
     }
 
     fun updateNote(note: Note, title: String, content: String, category: String) = viewModelScope.launch {


### PR DESCRIPTION
I made some minor adjustments to the implementation. Now navigating to the new screen no longer causes crashes, but the app still crashes when exiting the screen. The main issue is that the `Note` class cannot be saved using `rememberSaveable`. This is tricky to handle here. I recommend updating the value in the `ViewModel` instead of saving the `Note` directly within the screen UI.

